### PR TITLE
Upgrade to record processor v2

### DIFF
--- a/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
+++ b/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
@@ -1,17 +1,25 @@
 package com.kickstarter.jruby;
 
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.AmazonKinesisClient;
+import com.amazonaws.services.kinesis.leases.exceptions.LeasingException;
+import com.amazonaws.services.kinesis.leases.impl.KinesisClientLeaseManager;
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker;
-import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownReason;
+import com.amazonaws.services.kinesis.clientlibrary.types.InitializationInput;
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput;
+import com.amazonaws.services.kinesis.clientlibrary.types.ShutdownInput;
 import com.amazonaws.services.kinesis.model.Record;
-
-import java.util.List;
 
 /**
  * A shim that makes it possible to use the Kinesis Client Library from JRuby.
  * Without the shim, {@code initialize} method in
- * {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor}
+ * {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor}
  * conflicts with the special {@code initialize} method in Ruby. The shim
  * interface renames {@code initialize} to {@code init}.
  * <p />
@@ -36,67 +44,71 @@ public class Telekinesis {
      * {@link IRecordProcessorFactory}.
      */
     public static Worker newWorker(final KinesisClientLibConfiguration config, final IRecordProcessorFactory factory) {
-        return new Worker(new com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory() {
+        com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory v2Factory = new com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory() {
             @Override
-            public com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor createProcessor() {
+            public com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor createProcessor() {
                 return new RecordProcessorShim(factory.createProcessor());
             }
-        }, config);
+        };
+        return new Worker.Builder()
+            .recordProcessorFactory(v2Factory)
+            .config(config)
+            .build();
     }
 
     // ========================================================================
     /**
      * A shim that wraps a {@link IRecordProcessor} so it can get used by the KCL.
      */
-    private static class RecordProcessorShim implements com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor {
+    private static class RecordProcessorShim implements com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor {
         private final IRecordProcessor underlying;
 
         public RecordProcessorShim(final IRecordProcessor underlying) { this.underlying = underlying; }
 
         @Override
-        public void initialize(final String shardId) {
-            underlying.init(shardId);
+        public void initialize(final InitializationInput initializationInput) {
+            underlying.init(initializationInput);
         }
 
         @Override
-        public void processRecords(final List<Record> records, final IRecordProcessorCheckpointer checkpointer) {
-            underlying.processRecords(records, checkpointer);
+        public void processRecords(final ProcessRecordsInput processRecordsInput) {
+            underlying.processRecords(processRecordsInput);
         }
 
         @Override
-        public void shutdown(final IRecordProcessorCheckpointer checkpointer, final ShutdownReason reason) {
-            underlying.shutdown(checkpointer, reason);
+        public void shutdown(final ShutdownInput shutdownInput) {
+            underlying.shutdown(shutdownInput);
         }
     }
 
     /**
-     * A parallel {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor}
+     * A parallel {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor}
      * that avoids naming conflicts with reserved words in Ruby.
      */
     public static interface IRecordProcessor {
         /**
-         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor#initialize(String)
+         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor#initialize(InitializationInput)
          */
-        void init(final String shardId);
+        void init(InitializationInput initializationInput);
 
         /**
-         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor#processRecords(List, IRecordProcessorCheckpointer)
+         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor#processRecords(ProcessRecordsInput)
          */
-        void processRecords(List<Record> records, IRecordProcessorCheckpointer checkpointer);
+        void processRecords(ProcessRecordsInput processRecordsInput);
 
         /**
-         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor#shutdown(IRecordProcessorCheckpointer, ShutdownReason)
+         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor#shutdown(ShutdownInput)
          */
-        void shutdown(IRecordProcessorCheckpointer checkpointer, ShutdownReason reason);
+        void shutdown(ShutdownInput shutdownInput);
     }
 
     /**
-     * A parallel {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory}
+     * A parallel {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory}
      * for {@link IRecordProcessor}.
      */
     public static interface IRecordProcessorFactory {
         /**
-         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory#createProcessor()
+         * @see com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory#createProcessor()
          */
         IRecordProcessor createProcessor();
     }

--- a/lib/telekinesis/consumer/base_processor.rb
+++ b/lib/telekinesis/consumer/base_processor.rb
@@ -4,9 +4,9 @@ module Telekinesis
     # IRecordProcessor methods. Override it to implement simple IRecordProcessors
     # that don't need to do anything special on init or shutdown.
     class BaseProcessor
-      def init(shard_id); end
-      def process_records(records, checkpointer); end
-      def shutdown(checkpointer, reason); end
+      def init(initialization_input); end
+      def process_records(process_records_input); end
+      def shutdown(shutdown_input); end
     end
   end
 end

--- a/lib/telekinesis/consumer/block.rb
+++ b/lib/telekinesis/consumer/block.rb
@@ -4,8 +4,10 @@ module Telekinesis
     # quickly define a consumer.
     #
     # Telekinesis::Consumer::Worker.new(stream: 'my-stream', app: 'tail') do
-    #   Telekinesis::Consumer::Block.new do |records, checkpointer|
+    #   Telekinesis::Consumer::Block.new do |records, checkpointer, millis_behind_latest|
     #     records.each {|r| puts r}
+    #     $stderr.puts "#{millis_behind_latest} ms behind"
+    #     checkpointer.checkpoint
     #   end
     # end
     class Block < BaseProcessor
@@ -14,8 +16,8 @@ module Telekinesis
         @block = block
       end
 
-      def process_records(records, checkpointer)
-        @block.call(records, checkpointer)
+      def process_records(input)
+        @block.call(input.records, input.checkpointer, input.millis_behind_latest)
       end
     end
   end

--- a/lib/telekinesis/consumer/distributed_consumer.rb
+++ b/lib/telekinesis/consumer/distributed_consumer.rb
@@ -38,7 +38,7 @@ module Telekinesis
       # RecordProcessor interface - processors must implement `init`,
       # `process_records`, and `shutdown` methods.
       #
-      # http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-record-processor-implementation-app-java.html#kinesis-record-processor-implementation-interface-java
+      # http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-record-processor-implementation-app-java.html#kcl-java-interface-v2
       #
       # To specify which record processor to create, pass a block to your
       # distribtued consumer that returns a new record processor. This block
@@ -53,8 +53,10 @@ module Telekinesis
       # To write a stream tailer, you might use Block as follows:
       #
       #     Telekinesis::Consumer::DistributedConsumer.new(config) do
-      #       Telekinesis::Consumer::Block do |records, _|
+      #       Telekinesis::Consumer::Block.new do |records, checkpointer, millis_behind_latest|
       #         records.each {|r| puts r}
+      #         $stderr.puts "#{millis_behind_latest} ms behind"
+      #         checkpointer.checkpoint
       #       end
       #     end
       #


### PR DESCRIPTION
@blinsay, please review.

This upgrades to the [IRecordProcessor V2 interface](http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-record-processor-implementation-app-java.html#kcl-java-v2-migration) introduced in KCL 1.5.0.

Notable changes:
1. Init takes [InitializationInput](https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/InitializationInput.java#L22) allowing access to sequence number in addition to shard ID.
2. Process records takes [ProcessRecordsInput](https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/clientlibrary/types/ProcessRecordsInput.java#L26) exposing millis behind latest to give better clarity on how far behind a worker is in addition to records and checkpointer.