### PR TITLE
Missing .run call in main README.md example for KCL consumer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,11 @@ class MyProcessor
   end
 end
 
-Telekinesis::Consumer::KCL.new(stream: 'some-events', app: 'example') do
+worker = Telekinesis::Consumer::KCL.new(stream: 'some-events', app: 'example') do
   MyProcessor.new
 end
+
+worker.run
 ```
 
 To make defining record processors easier, Telekinesis comes with a `Block`
@@ -243,11 +245,13 @@ processor.
 ```ruby
 require 'telekinesis'
 
-Telekinesis::Consumer::KCL.new(stream: 'some-events', app: 'example') do
+worker = Telekinesis::Consumer::KCL.new(stream: 'some-events', app: 'example') do
   Telekinesis::Consumer::Block.new do |records, checkpointer, millis_behind|
     records.each {|r| puts "key=#{r.partition_key} value=#{String.from_java_bytes(r.data.array)}" }
   end
 end
+
+worker.run
 ```
 
 Once you get into building a client application, you'll probably want


### PR DESCRIPTION
This was confusing to me as a 1st time user I was attempting to create a consumer but it never ran.  Then I read further in the code and found that you must call .run to get it to startup.