### PR TITLE
Manage jars with lock jar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,8 @@
 source 'https://rubygems.org'
 gemspec
+
+# Trigger LockJar to run when Bundler finishes to create the Jarfile.lock
+@@check ||= at_exit do
+  require 'lock_jar/bundler'
+  LockJar::Bundler.lock!
+end

--- a/Jarfile
+++ b/Jarfile
@@ -1,0 +1,1 @@
+jar 'com.kickstarter:telekinesis:3.1.0'

--- a/Jarfile.lock
+++ b/Jarfile.lock
@@ -1,0 +1,49 @@
+---
+version: 0.15.0
+merged:
+- gem:telekinesis:Jarfile.lock
+groups:
+  default:
+    dependencies:
+    - com.amazonaws:amazon-kinesis-client:jar:1.6.1
+    - com.amazonaws:aws-java-sdk-cloudwatch:jar:1.10.20
+    - com.amazonaws:aws-java-sdk-core:jar:1.10.20
+    - com.amazonaws:aws-java-sdk-dynamodb:jar:1.10.20
+    - com.amazonaws:aws-java-sdk-kinesis:jar:1.10.20
+    - com.amazonaws:aws-java-sdk-kms:jar:1.10.20
+    - com.amazonaws:aws-java-sdk-s3:jar:1.10.20
+    - com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0
+    - com.fasterxml.jackson.core:jackson-core:jar:2.5.3
+    - com.fasterxml.jackson.core:jackson-databind:jar:2.5.3
+    - com.google.guava:guava:jar:18.0
+    - com.google.protobuf:protobuf-java:jar:2.6.1
+    - com.kickstarter:telekinesis:jar:3.1.0
+    - commons-codec:commons-codec:jar:1.6
+    - commons-lang:commons-lang:jar:2.6
+    - commons-logging:commons-logging:jar:1.1.3
+    - joda-time:joda-time:jar:2.8.1
+    - org.apache.httpcomponents:httpclient:jar:4.3.6
+    - org.apache.httpcomponents:httpcore:jar:4.3.3
+    artifacts:
+    - jar:com.kickstarter:telekinesis:jar:3.1.0:
+        transitive:
+          com.google.guava:guava:jar:18.0: {}
+          com.amazonaws:amazon-kinesis-client:jar:1.6.1:
+            com.amazonaws:aws-java-sdk-dynamodb:jar:1.10.20:
+              com.amazonaws:aws-java-sdk-s3:jar:1.10.20:
+                com.amazonaws:aws-java-sdk-kms:jar:1.10.20: {}
+            com.google.protobuf:protobuf-java:jar:2.6.1: {}
+            com.amazonaws:aws-java-sdk-kinesis:jar:1.10.20: {}
+            com.amazonaws:aws-java-sdk-cloudwatch:jar:1.10.20: {}
+            commons-lang:commons-lang:jar:2.6: {}
+            com.amazonaws:aws-java-sdk-core:jar:1.10.20:
+              org.apache.httpcomponents:httpclient:jar:4.3.6:
+                commons-codec:commons-codec:jar:1.6: {}
+                org.apache.httpcomponents:httpcore:jar:4.3.3: {}
+              commons-logging:commons-logging:jar:1.1.3: {}
+              com.fasterxml.jackson.core:jackson-databind:jar:2.5.3:
+                com.fasterxml.jackson.core:jackson-core:jar:2.5.3: {}
+                com.fasterxml.jackson.core:jackson-annotations:jar:2.5.0: {}
+              joda-time:joda-time:jar:2.8.1: {}
+remote_repositories:
+- http://repo1.maven.org/maven2/

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -2,9 +2,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <name>Telekinesis</name>
+    <description>Telekinesis is a high-level client for Amazon Kinesis.</description>
+    <url>https://github.com/kickstarter/telekinesis</url>
     <groupId>com.kickstarter</groupId>
     <artifactId>telekinesis</artifactId>
     <version>3.1.0</version>
+
+    <licenses>
+       <license>
+           <name>TBD</name>
+           <url>TBD</url>
+           <distribution>repo</distribution>
+       </license>
+   </licenses>
+
+   <scm>
+       <url>scm:git:https://github.com/kickstarter/telekinesis.git</url>
+       <developerConnection>scm:git:https://github.com/kickstarter/telekinesis.git</developerConnection>
+       <connection>scm:git:https://github.com/kickstarter/telekinesis.git</connection>
+   </scm>
+
+   <developers>
+        <developer>
+            <id>it</id>
+            <name>is silly</name>
+            <email>that@maven.demands.this</email>
+        </developer>
+    </developers>
 
     <distributionManagement>
        <repository>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -6,6 +6,14 @@
     <artifactId>telekinesis</artifactId>
     <version>3.1.0</version>
 
+    <distributionManagement>
+       <repository>
+           <id>nexus-releases</id>
+           <name>Nexus Release Repository</name>
+           <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+       </repository>
+   </distributionManagement>
+
     <!-- ================================================================== -->
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>
@@ -27,14 +35,6 @@
                 <configuration>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -60,4 +60,33 @@
         <aws-java-sdk-version>1.6.9.1</aws-java-sdk-version>
         <amazon-kinesis-client-version>1.6.1</amazon-kinesis-client-version>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -85,6 +85,30 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-source-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>attach-sources</id>
+                              <goals>
+                                  <goal>jar</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-javadoc-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>attach-javadocs</id>
+                              <goals>
+                                  <goal>jar</goal>
+                              </goals>
+                          </execution>
+                      </executions>
+                  </plugin>
                 </plugins>
             </build>
         </profile>

--- a/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
+++ b/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
@@ -24,13 +24,13 @@ import java.util.concurrent.ExecutorService;
  * {@link com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessor}
  * conflicts with the special {@code initialize} method in Ruby. The shim
  * interface renames {@code initialize} to {@code init}.
- * <p />
+ * <p>
  *
  * For convenience a {@link #newWorker(KinesisClientLibConfiguration, ExecutorService, IRecordProcessorFactory)}
  * method is provided, so you can use closure conversion in JRuby to specify an
  * {@link IRecordProcessorFactory}. For example
  *
- * <p />
+ * <p>
  *
  * <pre>
  *     executor = config[:executor] || nil

--- a/lib/telekinesis.rb
+++ b/lib/telekinesis.rb
@@ -4,8 +4,10 @@ unless RUBY_PLATFORM.match(/java/)
   raise "Sorry! Telekinesis is only supported on JRuby"
 end
 
+require 'lock_jar'
+LockJar.load(resolve: true) # load jar dependencies from Jarfile.lock
+
 require "telekinesis/version"
-require "telekinesis/telekinesis-#{Telekinesis::VERSION}.jar"
 require "telekinesis/java_util"
 require "telekinesis/logging/java_logging"
 require "telekinesis/aws"

--- a/telekinesis.gemspec
+++ b/telekinesis.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.files        = `git ls-files`.split($/) + Dir.glob("lib/telekinesis/*.jar")
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "lock_jar", "~> 0.15"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Uses [Lock Jar](https://github.com/mguymon/lock_jar) to handle the jar dependencies, removing the requirement if having to package the uber jar with the gem. RubyGem will rejoice not having to store a ~ 5meg jar with every release.

The other perk is, down stream projects can do dependency resolution with Telekinesis via Lock Jar. This was actually a problem I had were another jar dependency was conflicting with the guava version. 

The jar dependencies are installed to the local maven dir the first time [LockJar.load(resolve: true)](https://github.com/mguymon/telekinesis/blob/cf6019eae11772c5c0fabc83fb679bacb086094c/lib/telekinesis.rb#L7-L8). After that, the local jars are used. It is possible to pre fetch the jars when the gem is installed, but it will require [a Rakefile as the gem's extension](https://github.com/mguymon/telekinesis/blob/cf6019eae11772c5c0fabc83fb679bacb086094c/lib/telekinesis.rb#L7-L8)

For this to work, the Telekinesis jar will have to be [deployed to maven central](http://central.sonatype.org/pages/ossrh-guide.html) which is a bit of a PITA and requires a pom with a bunch of extra details. I went ahead it updated the pom xml and added a profile that sign's the jar when it deploys (otherwise it wants to sign it every time you package it). Releasing to maven central works by `mvn deploy -P release-sign-artifacts`.

To test locally, you have to do a `mvn install` first (until the jar is released to maven central). After that, all the specs pass as the jars are automatically loaded based on the `Jarfile.lock`.