### PR TITLE
add missing Java imports to JavaClientAdapter

### DIFF
--- a/lib/telekinesis/aws/java_client_adapter.rb
+++ b/lib/telekinesis/aws/java_client_adapter.rb
@@ -2,7 +2,9 @@ module Telekinesis
   module Aws
     java_import java.nio.ByteBuffer
     java_import com.amazonaws.AmazonClientException
+    java_import com.amazonaws.auth.BasicAWSCredentials
     java_import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+    java_import com.amazonaws.internal.StaticCredentialsProvider
     java_import com.amazonaws.services.kinesis.AmazonKinesisClient
     java_import com.amazonaws.services.kinesis.model.PutRecordRequest
     java_import com.amazonaws.services.kinesis.model.PutRecordsRequest

--- a/test/aws/test_java_client_adapter.rb
+++ b/test/aws/test_java_client_adapter.rb
@@ -69,4 +69,17 @@ class JavaClientAdapterTest < Minitest::Test
       end
     end
   end
+
+  context "JavaClientAdapter.build_credentials_provider" do
+    should "return a provider that provides the specified credentials" do
+      credentials = {
+        access_key_id: '0000000000',
+        secret_access_key: '0000000000',
+      }
+      provider = Telekinesis::Aws::JavaClientAdapter.build_credentials_provider(credentials)
+
+      assert_equal(credentials[:access_key_id], provider.credentials.aws_access_key_id)
+      assert_equal(credentials[:secret_access_key], provider.credentials.aws_secret_key)
+    end
+  end
 end

--- a/test/aws/test_java_client_adapter.rb
+++ b/test/aws/test_java_client_adapter.rb
@@ -68,18 +68,18 @@ class JavaClientAdapterTest < Minitest::Test
         end
       end
     end
-  end
 
-  context "JavaClientAdapter.build_credentials_provider" do
-    should "return a provider that provides the specified credentials" do
-      credentials = {
-        access_key_id: '0000000000',
-        secret_access_key: '0000000000',
-      }
-      provider = Telekinesis::Aws::JavaClientAdapter.build_credentials_provider(credentials)
+    context ".build_credentials_provider" do
+      should "return a provider that provides the specified credentials" do
+        credentials = {
+          access_key_id: '0000000000',
+          secret_access_key: '0000000000',
+        }
+        provider = Telekinesis::Aws::JavaClientAdapter.build_credentials_provider(credentials)
 
-      assert_equal(credentials[:access_key_id], provider.credentials.aws_access_key_id)
-      assert_equal(credentials[:secret_access_key], provider.credentials.aws_secret_key)
+        assert_equal(credentials[:access_key_id], provider.credentials.aws_access_key_id)
+        assert_equal(credentials[:secret_access_key], provider.credentials.aws_secret_key)
+      end
     end
   end
 end


### PR DESCRIPTION
`BasicAWSCredentials` and `StaticCredentialsProvider` are required when building an adapter with a non-empty credentials Hash.