### PR TITLE
the KCL can be configured with a DynamoDB client

### DIFF
--- a/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
+++ b/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
@@ -1,6 +1,6 @@
 package com.kickstarter.jruby;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker;
 import com.amazonaws.services.kinesis.clientlibrary.types.InitializationInput;
@@ -35,11 +35,11 @@ public class Telekinesis {
     /**
      * Create a new KCL {@link Worker} that processes records using the given
      * {@link ExecutorService} and {@link IRecordProcessorFactory}. Uses the
-     * given {@link AmazonDynamoDBClient} if non-null.
+     * given {@link AmazonDynamoDB} if non-null.
      */
     public static Worker newWorker(final KinesisClientLibConfiguration config,
                                    final ExecutorService executor,
-                                   final AmazonDynamoDBClient dynamoClient,
+                                   final AmazonDynamoDB dynamoClient,
                                    final IRecordProcessorFactory factory) {
         com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory v2Factory = new com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcessorFactory() {
             @Override

--- a/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
+++ b/ext/src/main/java/com/kickstarter/jruby/Telekinesis.java
@@ -34,8 +34,8 @@ import java.util.concurrent.ExecutorService;
 public class Telekinesis {
     /**
      * Create a new KCL {@link Worker} that processes records using the given
-     * {@link ExecutorService} and {@link IRecordProcessorFactory}. Uses the
-     * given {@link AmazonDynamoDB} if non-null.
+     * {@link ExecutorService}, {@link IRecordProcessorFactory}, and
+     * {@link AmazonDynamoDB}.
      */
     public static Worker newWorker(final KinesisClientLibConfiguration config,
                                    final ExecutorService executor,
@@ -48,16 +48,12 @@ public class Telekinesis {
             }
         };
 
-        Worker.Builder builder = new Worker.Builder()
+        return new Worker.Builder()
                 .recordProcessorFactory(v2Factory)
                 .config(config)
-                .execService(executor); // NOTE: .execService(null) is a no-op
-
-        if (dynamoClient != null) {
-            builder.dynamoDBClient(dynamoClient);
-        }
-
-        return builder.build();
+                .execService(executor) // NOTE: .execService(null) is a no-op
+                .dynamoDBClient(dynamoClient)
+                .build();
     }
 
     // ========================================================================

--- a/lib/telekinesis/consumer/kcl.rb
+++ b/lib/telekinesis/consumer/kcl.rb
@@ -23,6 +23,12 @@ module Telekinesis
       # client in the same `:app` on the same host, make sure you set this to
       # something unique!).
       #
+      # Note: to configure the KCL clients to talk to a local DynamoDB server,
+      # pass in an instance of `AmazonDynamoDBClient` configured to talk to a
+      # local server as the second (optional) parameter to the KCL initialize
+      # method. If not provided, the KCL client will talk to AWS DynamoDB
+      # directly.
+      #
       # Any other valid KCL Worker `:options` may be passed as a nested hash.
       #
       # For example, to configure a `tail` app on `some-stream` and use the
@@ -64,10 +70,10 @@ module Telekinesis
       #
       #     kcl_worker.run
       #
-      def initialize(config, &block)
+      def initialize(config, dynamo_client = null, &block)
         raise ArgumentError, "No block given!" unless block_given?
         kcl_config = self.class.build_config(config)
-        @under = com.kickstarter.jruby.Telekinesis.new_worker(kcl_config, config[:executor], &block)
+        @under = com.kickstarter.jruby.Telekinesis.new_worker(kcl_config, config[:executor], dynamo_client, &block)
       end
 
       # Return the underlying KCL worker. It's a java.lang.Runnable.

--- a/lib/telekinesis/consumer/kcl.rb
+++ b/lib/telekinesis/consumer/kcl.rb
@@ -23,11 +23,9 @@ module Telekinesis
       # client in the same `:app` on the same host, make sure you set this to
       # something unique!).
       #
-      # Note: to configure the KCL clients to talk to a local DynamoDB server,
-      # pass in an instance of `AmazonDynamoDBClient` configured to talk to a
-      # local server as the second (optional) parameter to the KCL initialize
-      # method. If not provided, the KCL client will talk to AWS DynamoDB
-      # directly.
+      # Clients interested in configuring their own AmazonDynamoDB client may
+      # pass an instance as the second argument. If not configured, the client
+      # will use a default AWS configuration.
       #
       # Any other valid KCL Worker `:options` may be passed as a nested hash.
       #

--- a/lib/telekinesis/consumer/kcl.rb
+++ b/lib/telekinesis/consumer/kcl.rb
@@ -68,7 +68,7 @@ module Telekinesis
       #
       #     kcl_worker.run
       #
-      def initialize(config, dynamo_client = null, &block)
+      def initialize(config, dynamo_client = nil, &block)
         raise ArgumentError, "No block given!" unless block_given?
         kcl_config = self.class.build_config(config)
         @under = com.kickstarter.jruby.Telekinesis.new_worker(kcl_config, config[:executor], dynamo_client, &block)


### PR DESCRIPTION
Provides a mechanism that gives clients the ability to setup the KCL worker to talk to local DynamoDB instead of AWS, for example.