### PR TITLE
add optional endpoint specification for producers

### DIFF
--- a/lib/telekinesis/aws/java_client_adapter.rb
+++ b/lib/telekinesis/aws/java_client_adapter.rb
@@ -19,8 +19,10 @@ module Telekinesis
       # `:access_key_id` and `:secret_access_key`. If this hash is left blank
       # (the default) the client uses the DefaultAWSCredentialsProviderChain to
       # look for credentials.
-      def self.build(credentials = {})
+      # `:endpoint` is an optionally provided Kinesis URI
+      def self.build(credentials = {}, endpoint = nil)
         client = AmazonKinesisClient.new(build_credentials_provider(credentials))
+        client.set_endpoint(endpoint) if endpoint
         new(client)
       end
 

--- a/lib/telekinesis/producer/async_producer.rb
+++ b/lib/telekinesis/producer/async_producer.rb
@@ -24,6 +24,9 @@ module Telekinesis
       # If unspecified, credentials will be fetched from the environment, an
       # ~/.aws/credentials file, or the current instance metadata.
       #
+      # An alternative Kinesis endpoint may be specified by using the `:endpoint`
+      # option and passing the URI into the Client builder.
+      #
       # The producer's `:worker_count`, internal `:queue_size`, the `:send_size`
       # of batches to Kinesis and how often workers send data to Kinesis, even
       # if their batches aren't full (`:send_every_ms`) can be configured as
@@ -34,7 +37,10 @@ module Telekinesis
       # is used.
       def self.create(options = {})
         stream = options[:stream]
-        client = Telekinesis::Aws::Client.build(options.fetch(:credentials, {}))
+        client = Telekinesis::Aws::Client.build(
+          options.fetch(:credentials, {}),
+          options[:endpoint]
+        )
         failure_handler = options.fetch(:failure_handler, NoopFailureHandler.new)
         new(stream, client, failure_handler, options)
       end

--- a/lib/telekinesis/producer/sync_producer.rb
+++ b/lib/telekinesis/producer/sync_producer.rb
@@ -19,7 +19,10 @@ module Telekinesis
       # in `put_all`. See `put_all` for more info.
       def self.create(options = {})
         stream = options[:stream]
-        client = Telekinesis::Aws::Client.build(options.fetch(:credentials, {}))
+        client = Telekinesis::Aws::Client.build(
+          options.fetch(:credentials, {}),
+          options[:endpoint]
+        )
         new(stream, client, failure_handler, options)
       end
 


### PR DESCRIPTION
Provides the ability to specify a Kinesis endpoint (e.g. for use with [Kinesalite](https://github.com/mhart/kinesalite)). This is supported by KCL but that option is not currently passed through.

@blinsay, please review. Thanks!