### PR TITLE
Pass cause message to message in KinesisError

### DIFF
--- a/lib/telekinesis/aws/client_adapter.rb
+++ b/lib/telekinesis/aws/client_adapter.rb
@@ -6,6 +6,7 @@ module Telekinesis
 
       def initialize(cause)
         @cause = cause
+        super(cause.message)
       end
     end
 


### PR DESCRIPTION
Sets the message for `KinesisError` to the same as the cause message. 

The useful error messaging from Amazon get swallowed without this and it's very hard to diagnose problems